### PR TITLE
Enable support for Markdown tables

### DIFF
--- a/scripts/js/lava-flow.js
+++ b/scripts/js/lava-flow.js
@@ -201,7 +201,10 @@ class LavaFlow {
 
     static async getFileContent(file) {
         let markdown = await file.text();
-        let converter = new showdown.Converter();
+        let converter = new showdown.Converter({
+            tables: 'true',
+            tablesHeaderId: 'true'
+        });
         return converter.makeHtml(markdown);
     }
 


### PR DESCRIPTION
Set Showdown options `tables` to enable support for markdown tables and
`tablesHeaderId` to add an id property to table header tags.

See: https://github.com/showdownjs/showdown/wiki/Showdown-options#tables