### PR TITLE
exclude the whole .obsidian and .trash folders 

### DIFF
--- a/scripts/js/lava-flow.js
+++ b/scripts/js/lava-flow.js
@@ -155,7 +155,7 @@ class LavaFlow {
     }
 
     static async importFile(file, settings, rootFolder) {
-        if (!file || file.name == ".obsidian")
+        if (!file || file.webkitRelativePath.includes(".obsidian") || file.webkitRelativePath.includes(".trash"))
             return;
         let fileNameParts = file.name.split('.');
         let fileExtension = fileNameParts[fileNameParts.length - 1].toLowerCase();


### PR DESCRIPTION
On File import, ignore all files containing the ".obsidian" and ".trash" folders in their filepath.

Changed the check from filename only to ".include" on the path since it only excludes the folder itself otherwise. Also added the ".trash" folder since it shouldn't contain any files of interest which would get needlessly imported otherwise.

Feel free to change/deny if my fix is wrong.