### PR TITLE
Bugfix/40 create img path

### DIFF
--- a/src/lava-flow.ts
+++ b/src/lava-flow.ts
@@ -135,14 +135,8 @@ export default class LavaFlow {
   static async importOtherFile(file: OtherFileInfo, settings: LavaFlowSettings): Promise<void> {
     const source = settings.useS3 ? 's3' : 'data';
     const body = settings.useS3 ? { bucket: settings.s3Bucket } : {};
-    const promise = FilePicker.upload(source, settings.mediaFolder, file.originalFile, body);
-    let path = `${settings.mediaFolder}/${file.originalFile.name}`;
-    path.replace('//', '/');
-    if (settings.useS3) {
-      path = `https://${settings.s3Bucket}.s3.${settings.s3Region}.amazonaws.com/${path}`;
-    }
-    file.uploadPath = path;
-    await promise;
+    const uploadResponse: any = await FilePicker.upload(source, settings.mediaFolder, file.originalFile, body);
+    if (uploadResponse?.path) file.uploadPath = decodeURI(uploadResponse.path);
   }
 
   static async validateUploadLocation(settings: LavaFlowSettings): Promise<void> {

--- a/src/lava-flow.ts
+++ b/src/lava-flow.ts
@@ -148,15 +148,16 @@ export default class LavaFlow {
   static async validateUploadLocation(settings: LavaFlowSettings): Promise<void> {
     if (settings.useS3) {
       if (settings.s3Bucket === null || settings.s3Region === null) throw new Error('S3 settings are invalid.');
-    }
-    try {
-      let pickerPromise = await FilePicker.browse('data', settings.mediaFolder);
-      return;
-    } catch (error: any) {
-      LavaFlow.log(`Error accessing filepath ${settings.mediaFolder}: ${error.message}`, false);
-    }
+    } else {
+      try {
+        await FilePicker.browse('data', settings.mediaFolder);
+        return;
+      } catch (error: any) {
+        LavaFlow.log(`Error accessing filepath ${settings.mediaFolder}: ${error.message}`, false);
+      }
 
-    await FilePicker.createDirectory('data', settings.mediaFolder);
+      await FilePicker.createDirectory('data', settings.mediaFolder);
+    }
   }
 
   static async createIndexFile(


### PR DESCRIPTION
Resolves #40.
- Uses @SomeOats fix to create local paths that do not exist.
- Added a fix so that the local path will not be created if using S3.
- Uses the path returned from the FilePicker to set the file path.